### PR TITLE
Update .terraform.lock.hcl

### DIFF
--- a/terraform/hcp/.terraform.lock.hcl
+++ b/terraform/hcp/.terraform.lock.hcl
@@ -1,26 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/hcp" {
-  version     = "0.50.0"
-  constraints = "0.50.0"
-  hashes = [
-    "h1:B1R6BMF4rwBbCm9jMlgpZD9STHBdyuN9XNwGGJMlcYI=",
-    "zh:077a3a88c594f22c6b83bda0a17c2eef2015b1c229d829c1fa723de09cefe921",
-    "zh:0f7f14a3e00dfb67ef5cf745e96641dbf627a467272ae496f4c99e84c29af477",
-    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
-    "zh:4d58527a7b70374961818f9d8ee145ee1ad9ca634d1a848e722d479219e52b4a",
-    "zh:4e616a9cfcda5b083d01d99b44b6ea97ffd740b85426c20bc31c5faf268521ac",
-    "zh:74caab1ece07f541df420fc685071568b669f20fe596a88e379b5eda1c6a8938",
-    "zh:7d6e80aba32dd3c91d258ee9d434bc2e10daf27041cf1accd282858ad18e138f",
-    "zh:91e5a0e3b0fafbd780eb2120939426c4142036eb3e354c744287e320f3b361ed",
-    "zh:977b245e1760ea939a55fbef89aebb127242d641d09808934fca62d263b3a312",
-    "zh:997c4ba1e0b3f0d11241785d387d2d4081d8f132ec07af841f548733c8726210",
-    "zh:a38398783785d39bb27f54ca3dc60a4713d5557655aaee76f924e107c87e79bd",
-    "zh:b32c723c998c803e2c92ec34e8e9fda45b0671fbd1b799139aecd15e879d85f4",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/http" {
   version = "3.2.1"
   hashes = [


### PR DESCRIPTION
also removing the HCP provider from the lock file, since the version is defined in main.tf