### PR TITLE
Updated the image for the boundary-worker for k8s

### DIFF
--- a/terraform/infra_setup/k8s_cluster/main.tf
+++ b/terraform/infra_setup/k8s_cluster/main.tf
@@ -199,7 +199,7 @@ locals {
           containers = [
             {
               name = "boundary-worker"
-              image = "hashicorp/boundary-worker-hcp"
+              image = "hashicorppreview/boundary-worker-hcp:0.12-dev"
               command = [ "boundary-worker" ]
               args = [ "server", "-config", "/etc/boundary/boundary-worker-config" ]
               securityContext = {


### PR DESCRIPTION
In the current instruqt track, applying the worker-yamls leads to an error: the image is not found. Apparently the image was moved from hashicorp to hashicorppreview.